### PR TITLE
process: Adds process.mainArgs

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -568,12 +568,12 @@ added: v0.1.27
 
 * {string[]}
 
-The `process.argv` property returns an array containing the command line
-arguments passed when the Node.js process was launched. The first element will
-be [`process.execPath`][]. See `process.argv0` if access to the original value
-of `argv[0]` is needed. The second element will be the path to the JavaScript
-file being executed. The remaining elements will be any additional command line
-arguments.
+The `process.argv` property returns an array in which the first element will be
+[`process.execPath`][]. See `process.argv0` if access to the original value of
+`argv[0]` is needed. The second element will be the path to the JavaScript file
+being executed. The remaining elements will be any additional command line
+arguments passed when the Node.js process was launched, same as
+[`process.mainArgs`][].
 
 For example, assuming the following script for `process-args.js`:
 
@@ -1424,6 +1424,38 @@ process.kill(process.pid, 'SIGHUP');
 
 When `SIGUSR1` is received by a Node.js process, Node.js will start the
 debugger. See [Signal Events][].
+
+## process.mainArgs
+<!-- YAML
+added: REPLACEME
+-->
+
+The `process.mainArgs` property returns an array containing the command line
+arguments passed when the Node.js process was launched.
+
+For example, assuming the following script for `process-args.js`:
+
+```js
+// Print process.mainArgs
+process.mainArgs.forEach((val, index) => {
+  console.log(`${index}: ${val}`);
+});
+```
+
+Launching the Node.js process as:
+
+```console
+$ node process-args.js one two=three four
+```
+
+Would generate the output:
+
+```text
+0: one
+1: two=three
+2: four
+```
+* {string[]}
 
 ## process.mainModule
 <!-- YAML
@@ -2446,6 +2478,7 @@ cases:
 [`process.hrtime()`]: #process_process_hrtime_time
 [`process.hrtime.bigint()`]: #process_process_hrtime_bigint
 [`process.kill()`]: #process_process_kill_pid_signal
+[`process.mainArgs`]: #process_process_mainargs
 [`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
 [`promise.catch()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
 [`Promise.race()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -316,6 +316,13 @@ function setupPrepareStackTrace() {
   setEnhanceStackForFatalException(beforeInspector, afterInspector);
 }
 
+const { mainArgs } = require('internal/process/main_args');
+Object.defineProperty(process, 'mainArgs', {
+  configurable: true,
+  enumerable: true,
+  get: mainArgs
+});
+
 function setupProcessObject() {
   const EventEmitter = require('events');
   const origProcProto = Object.getPrototypeOf(process);

--- a/lib/internal/process/main_args.js
+++ b/lib/internal/process/main_args.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function mainArgs() {
+  const { mainModule } = process;
+  const trailingArgsCount = mainModule ? 2 : 1;
+  return process.argv.slice(trailingArgsCount);
+}
+
+module.exports = {
+  mainArgs
+};

--- a/node.gyp
+++ b/node.gyp
@@ -160,6 +160,7 @@
       'lib/internal/priority_queue.js',
       'lib/internal/process/esm_loader.js',
       'lib/internal/process/execution.js',
+      'lib/internal/process/main_args.js',
       'lib/internal/process/main_thread_only.js',
       'lib/internal/process/per_thread.js',
       'lib/internal/process/policy.js',

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -51,6 +51,7 @@ const expectedModules = new Set([
   'NativeModule internal/options',
   'NativeModule internal/priority_queue',
   'NativeModule internal/process/execution',
+  'NativeModule internal/process/main_args',
   'NativeModule internal/process/per_thread',
   'NativeModule internal/process/promises',
   'NativeModule internal/process/task_queues',

--- a/test/parallel/test-cli-mainArgs.js
+++ b/test/parallel/test-cli-mainArgs.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const child = require('child_process');
+const nodejs = `"${process.execPath}"`;
+
+// Assert that mainArgs value is correct when using eval cli option
+child.exec(
+  `${nodejs} --eval "console.log(process.mainArgs.join(' '))" one two three`,
+  common.mustCall((err, stdout, stderr) => {
+    assert.ifError(err);
+    assert.strictEqual(stdout, 'one two three\n');
+    assert.strictEqual(stderr, '');
+  }));
+
+// Assert that mainArgs value is correct when using print cli option
+child.exec(
+  `${nodejs} --print process.mainArgs one two three`,
+  common.mustCall((err, stdout, stderr) => {
+    assert.ifError(err);
+    assert.strictEqual(stdout, '[ \'one\', \'two\', \'three\' ]\n');
+    assert.strictEqual(stderr, '');
+  }));

--- a/test/parallel/test-process-mainArgs.js
+++ b/test/parallel/test-process-mainArgs.js
@@ -1,0 +1,13 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+// Tests that process.mainArgs returns all arguments provided
+if (process.mainArgs[0] === 'child') {
+  console.log(process.mainArgs.join(' '));
+  return;
+}
+
+const child = spawnSync(process.execPath, [__filename, 'child', '-a', 'one']);
+assert.strictEqual(child.stdout.toString().trim(), 'child -a one');


### PR DESCRIPTION
Adds the `process.mainArgs` API that returns only the command line arguments that were set for the running program, effectively providing a more user-friendly alternative to `process.argv` by removing the `process.execPath` and the executed filename that are historically part
of the array of arguments returned.

## Background

This proposal is the result of the work done by the [Tooling workgroup](https://github.com/nodejs/tooling/) that have been trying to advance towards a better solution for the problem of parsing arguments without usage of user-land modules.

The rationale behind why we would like to add this new API to Node core has been [extensively documented within the working group related issue](https://github.com/nodejs/tooling/issues/19) but it comes down to:

- Provide a more inclusive API that is friendlier to newcomers to the ecosystem
- Provide a better developer experience when retrieving command line arguments

## Proposal

While this is far from a fully fledged argument parser system as [discussed in the related issue](https://github.com/nodejs/tooling/issues/19), the consensus within the working group is that it still helps a lot in our effort towards a healthier API for everyone that wants to deal with cli arguments using node.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
